### PR TITLE
Clarify memory model for rs2

### DIFF
--- a/zicondops.adoc
+++ b/zicondops.adoc
@@ -94,10 +94,9 @@ Furthermore, implementations can predict the condition just as they might for br
 SAIL code::
 [source,sail]
 --
-  let value = X(rs1);
   let condition = X(rs2);
   result : xlenbits = if (condition == zeros()) then zeros()
-                                                else value;
+                                                else X(rs1);
   X(rd) = result;
 --
 
@@ -153,10 +152,9 @@ Furthermore, implementations can predict the condition just as they might for br
 SAIL code::
 [source,sail]
 --
-  let value = X(rs1);
   let condition = X(rs2);
   result : xlenbits = if (condition != zeros()) then zeros()
-                                                else value;
+                                                else X(rs1);
   X(rd) = result;
 --
 

--- a/zicondops.adoc
+++ b/zicondops.adoc
@@ -79,6 +79,7 @@ Encoding::
 Description::
 This instruction behaves as if there is a conditional branch dependent on _rs2_ being equal to zero, wherein it branches to code that writes a 0 into _rd_ when the equivalence is true, and otherwise falls through to code that moves _rs1_ into _rd_.
 Accordingly, the syntactic dependency on _rs1_ is only propagated when the condition is false.
+This instruction has a control dependency on _rs2_, rather than a data dependency.
 Furthermore, this instruction's timing is independent of the data value of _rs1_ if the Zkt extension is implemented. +
 
 In effect, if the value of register _rs2_ is zero, place 0 (zero) into the register _rd_; otherwise, place the value of register _rs1_ into _rd_.
@@ -137,6 +138,7 @@ Encoding::
 Description::
 This instruction behaves as if there is a conditional branch dependent on _rs2_ being not equal to zero, wherein it branches to code that writes a 0 into _rd_ when the equivalence is true, and otherwise falls through to code that moves _rs1_ into _rd_.
 Accordingly, the syntactic dependency on _rs1_ is only propagated when the condition is false.
+This instruction has a control dependency on _rs2_, rather than a data dependency.
 Furthermore, this instruction's timing is independent of the data value of _rs1_ if the Zkt extension is implemented. +
 
 In effect, if the value of register _rs2_ is non-zero, place 0 (zero) into the register _rd_; otherwise, place the value of register _rs1_ into _rd_.


### PR DESCRIPTION
State that the dependency on rs2 is a control dependency rather than a data dependency. I reused the wording from the V extension, the formalisation of what that "control dependency" means will be the same.