### PR TITLE
Changing SAIL code to reflect change back to Zkt version

### DIFF
--- a/zicondops.adoc
+++ b/zicondops.adoc
@@ -85,9 +85,10 @@ Furthermore, if the Zkt extension is implemented, this instruction's timing is i
 SAIL code::
 [source,sail]
 --
+  let value = X(rs1);
   let condition = X(rs2);
   result : xlenbits = if (condition == zeros()) then zeros()
-                                                else X(rs1);
+                                                else value;
   X(rd) = result;
 --
 
@@ -123,9 +124,10 @@ Furthermore, if the Zkt extension is implemented, this instruction's timing is i
 SAIL code::
 [source,sail]
 --
+  let value = X(rs1);
   let condition = X(rs2);
   result : xlenbits = if (condition != zeros()) then zeros()
-                                                else X(rs1);
+                                                else value;
   X(rd) = result;
 --
 


### PR DESCRIPTION
With the change to a constant-time version of the ops, the SAIL code should match so the memory model implications are corrected.